### PR TITLE
Added `<scope>test</scope>` to test dependencies

### DIFF
--- a/transpiler/pom.xml
+++ b/transpiler/pom.xml
@@ -44,11 +44,13 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.13</artifactId>
             <version>3.2.10</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.29</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
While using `py2eo` in `polystat-cli` and inspecting the dependency tree I have noticed that `py2eo` jar contains `scalatest` as a direct dependency. If you add the test scope to scalatest, it won't be included in the published jar.